### PR TITLE
Fix deprecation warnings

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,11 +9,11 @@
     <article>
         <div class="main-content__posts index-posts">
             {{ $currentPage := . }}
-            {{ if eq $currentPage.URL "/post/" }}
+            {{ if eq $currentPage.Permalink "/post/" }}
                 {{ range .Pages }}
                 <div class="index-posts__list">
-                    <div class="l-time"><a href="{{.Permalink}}">{{ .Date.Format "2006.01.02 15:04" }}</a></div>
-                    <div class="l-title"><a href="{{.Permalink}}">{{ .Title }}</a></div>
+                    <div class="l-time"><a href="{{.URL}}">{{ .Date.Format "2006.01.02 15:04" }}</a></div>
+                    <div class="l-title"><a href="{{.URL}}">{{ .Title }}</a></div>
                 </div>
                 {{ end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,5 +31,5 @@
     </script>
     {{ end }}
     <!-- Hugo version -->
-    {{ .Hugo.Generator -}}
+    {{ hugo.Generator -}}
 </head>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,7 +7,7 @@
             <div></div>
         </div>
         {{ $currentPage := . }}
-        <div class='{{ if eq $currentPage.URL "/" }} site-logo site-logo__index {{ else }} site-logo {{ end }}'>
+        <div class='{{ if eq $currentPage.Permalink "/" }} site-logo site-logo__index {{ else }} site-logo {{ end }}'>
             <a href="{{ .Site.BaseURL }}">
                 {{- with .Site.Params.logo -}}
                 <img src="{{ . | absURL }}" />

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,5 +1,5 @@
 {{ $currentNode := . }}
-<div class='{{ if eq $currentNode.URL "/" }} site-nav site-nav__index u-font {{ else }} site-nav u-font {{ end }}' id="nav-bar">
+<div class='{{ if eq $currentNode.Permalink "/" }} site-nav site-nav__index u-font {{ else }} site-nav u-font {{ end }}' id="nav-bar">
     {{ range .Site.Menus.nav }}
     <div class="site-nav__wrap">
         <a class="site-nav__el" href="{{ .URL }}" >{{ .Name }}</a>

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -35,12 +35,12 @@
 
         <!-- First page. -->
         {{ if ne $pag.PageNumber 1 }}
-        <li><a href="{{ $pag.First.URL }}">&#60;&#60;</a></li>
+        <li><a href="{{ $pag.First.Permalink }}">&#60;&#60;</a></li>
         {{ end }}
 
         <!-- Previous page. -->
         {{ if $pag.HasPrev }}
-        <li><a href="{{ $pag.Prev.URL }}">&#60;</a></li>
+        <li><a href="{{ $pag.Prev.Permalink }}">&#60;</a></li>
         {{ end }}
 
         <!-- Page numbers. -->
@@ -98,12 +98,12 @@
 
         <!-- Next page. -->
         {{ if $pag.HasNext }}
-        <li><a href="{{ $pag.Next.URL }}">&#62;</a></li>
+        <li><a href="{{ $pag.Next.Permalink }}">&#62;</a></li>
         {{ end }}
 
         <!-- Last page. -->
         {{ if ne $pag.PageNumber $pag.TotalPages }}
-        <li><a href="{{ $pag.Last.URL }}">&#62;&#62;</a></li>
+        <li><a href="{{ $pag.Last.Permalink }}">&#62;&#62;</a></li>
         {{ end }}
 
     </ul>


### PR DESCRIPTION
Hi:

This PR fixes deprecation warnings that occur with:

```
Hugo Static Site Generator v0.60.1/extended darwin/amd64 BuildDate: unknown
```

when building sites that use this theme.